### PR TITLE
feat: stop server

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@
 // npm install --save spawn-pouchdb-server
 var spawnPouchdbServer = require('spawn-pouchdb-server')
 
-spawnPouchdbServer(function (error) {
+spawnPouchdbServer(function (error, server) {
   console.log('PouchDB Server stared at localhost:5985/_utils')
+  server.stop(function () {
+    console.log('PouchDB Server stopped')
+  })
 })
 ```
 
@@ -54,7 +57,7 @@ spawnPouchdbServer({
   },
   timeout: 10000, // in ms
   verbose: false
-}, function (error) {
+}, function (error, server) {
   console.log('PouchDB Server stared at localhost:5985/_utils')
 })
 ```

--- a/index.js
+++ b/index.js
@@ -78,9 +78,17 @@ function spawnPouchdbServer (options, callback) {
     pouchDbServer.backend = options.backend
     pouchDbServer.config = options.config
 
+    var killMainProcessOnExit = true
+
+    pouchDbServer.stop = function (callback) {
+      killMainProcessOnExit = false
+      pouchDbServer.on('exit', callback)
+      pouchDbServer.kill()
+    }
+
     // Stop main process when PouchDB Server dies.
     pouchDbServer.on('exit', function (code) {
-      process.exit(code)
+      if (killMainProcessOnExit) process.exit(code)
     })
 
     // Kill PouchDB server when main process dies


### PR DESCRIPTION
Add `server.stop` method which is exposed to the callback:

``` js
spawnPouchdbServer(function (error, server) {
  console.log('PouchDB Server stared at localhost:5985/_utils')
  server.stop(function () {
    console.log('PouchDB Server stopped')
  })
})
```

The main process is not killed in case pouchdb server is stopped via
`server.stop()`.

Closes #14
