### PR TITLE
fix: test for serverUp from server vs logLevel depedent logFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = spawnPouchdbServer
 
 var fs = require('fs')
-
+var http = require('http')
 var async = require('async')
 var relative = require('require-relative')
 var spawn = require('cross-spawn')
@@ -57,22 +57,22 @@ function spawnPouchdbServer (options, callback) {
     })
 
     var timeout = setTimeout(function () {
-      fs.unwatchFile(startlog, watch)
       callback(new Error('Timeout: PouchDB did not start after ' + options.timeout + 'ms.'))
     }, options.timeout)
 
-    fs.watchFile(startlog, {interval: 100}, watch)
+    var testForServerUp = setInterval(pingServer, 100)
+    var serverUp
 
-    function watch () {
-      var log = fs.readFileSync(startlog, {
-        encoding: 'utf8'
-      })
-
-      if (/navigate to .* for the Fauxton UI/.test(log)) {
-        callback(null, pouchDbServer)
-        fs.unwatchFile(startlog, watch)
+    function pingServer () {
+      var port = options.config.httpd.port
+      var req = http.get('http://localhost:' + port, () => {
+        if (options.verbose) console.log('pouchdb-server up')
+        if (!serverUp) callback(null, pouchDbServer)
+        serverUp = true
         clearTimeout(timeout)
-      }
+        clearInterval(testForServerUp)
+      })
+      req.on('error', function (err) { if (err) { return } })
     }
 
     pouchDbServer.backend = options.backend


### PR DESCRIPTION
# problem statement
- whist spawn-pdbs sniffs for its sever to come up before calling back, it checks for a string present in a log file
  - this is unreliable--logFile content is dependent on `logLevel`, which may not echo anything
  - my server "wouldn't come up", and I found it was because express-pouchdb wasn't logging the `match`ed content, even though the server was indeed up
# solution
- test for server-up by polling the server primary URL via `GET` instead of checking log file

cheers! :beers: 
